### PR TITLE
Re-subscribe to control topics on MQTT reconnect

### DIFF
--- a/ESPBlinds.ino
+++ b/ESPBlinds.ino
@@ -231,6 +231,16 @@ void mqttReconnect() {
     if (mqttClient.connect(MQTT_CLIENT_ID, MQTT_USER, MQTT_PASSWORD, MQTT_TOPIC_STATUS, 1, true, "disconnected", false)) {
       Serial.println("connected");
       mqttClient.publish(MQTT_TOPIC_STATUS, "connected", true);
+      // Re-subscribe to control topics after reconnecting
+      mqttClient.subscribe(MQTT_TOPIC_CONTROL_ENABLED);
+      mqttClient.subscribe(MQTT_TOPIC_CONTROL_DIRECTION);
+      mqttClient.subscribe(MQTT_TOPIC_CONTROL_STEPFOR);
+      mqttClient.subscribe(MQTT_TOPIC_CONTROL_BLINDS);
+      mqttClient.subscribe(MQTT_TOPIC_CONTROL_MODE_OPEN);
+      mqttClient.subscribe(MQTT_TOPIC_CONTROL_MODE_CLOSE);
+      mqttClient.subscribe(MQTT_TOPIC_CONTROL_DELAY_OPEN);
+      mqttClient.subscribe(MQTT_TOPIC_CONTROL_DELAY_CLOSE);
+      mqttClient.subscribe(MQTT_TOPIC_CONTROL_STEPS_VERTICAL);
     } else {
       Serial.print("failed, rc=");
       Serial.print(mqttClient.state());


### PR DESCRIPTION
## Summary
- Ensure `mqttReconnect` re-subscribes to all control topics after reconnecting to MQTT

## Testing
- `arduino-cli compile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6253dc1c83328645f1f8b066ccf6